### PR TITLE
Add admin portal naming meta

### DIFF
--- a/src/queries/models/dnn_stream.py
+++ b/src/queries/models/dnn_stream.py
@@ -6,5 +6,8 @@ class DnnStream(models.Model):
     max_number_of_splits = models.PositiveSmallIntegerField(blank=True, null=True,
                                                     help_text='maximum allowed number of splits for this stream')
 
+    def __str__(self):
+        return self.type
+
     class Meta:
         db_table = 'dnn_streams'

--- a/src/queries/models/video.py
+++ b/src/queries/models/video.py
@@ -9,3 +9,6 @@ class Video(models.Model):
 
     class Meta:
         db_table = 'video'
+
+    def __str__(self):
+        return self.name

--- a/src/queries/models/video_clip.py
+++ b/src/queries/models/video_clip.py
@@ -19,3 +19,5 @@ class VideoClip(models.Model):
             }
         }
 
+    def __str__(self):
+        return self.video.name + ', clip #' + str(self.clip)


### PR DESCRIPTION
Hello Chad,  these changes are for using the Django admin views of the database.  They specify names for items that really need the names rather than just the id number, in order to make sense to an admin user.