### PR TITLE
change updates so they only get the user_match information from the m…

### DIFF
--- a/src/queries/models/match.py
+++ b/src/queries/models/match.py
@@ -76,7 +76,7 @@ class Match(models.Model):
         Location of video this match is associated with.
         """
         clip = VideoClip.objects.get(id=self.video_clip_id)
-        return str(clip.duration * (clip.clip - 1)) + ',' + str(clip.duration * (clip.clip))
+        return "{},{}".format(clip.duration * (clip.clip - 1), clip.duration * clip.clip)
 
     @property
     def is_match(self):

--- a/src/queries/models/match.py
+++ b/src/queries/models/match.py
@@ -68,7 +68,7 @@ class Match(models.Model):
         return Video.objects.values_list('path', flat=True).get(id=video_id)
 
     @property
-    def match_video_start_time(self):
+    def match_video_time_span(self):
         """
         TODO: CHAD - Consider perf of multiple calls to VideoClip.
         Used on UI to calc reference time for matching video (../existing-query)
@@ -76,7 +76,7 @@ class Match(models.Model):
         Location of video this match is associated with.
         """
         clip = VideoClip.objects.get(id=self.video_clip_id)
-        return clip.duration * (clip.clip - 1)
+        return str(clip.duration * (clip.clip - 1)) + ',' + str(clip.duration * (clip.clip))
 
     @property
     def is_match(self):

--- a/src/queries/serializers.py
+++ b/src/queries/serializers.py
@@ -53,7 +53,7 @@ class MatchSerializer(serializers.ModelSerializer):
         model = Match
         fields = (
             'id', 'query_result', 'score', 'user_match', 'video_clip', 'query_id', 'reference_video_id',
-            'reference_time', 'match_video_path', 'match_video_start_time', 'is_match'
+            'reference_time', 'match_video_path', 'match_video_time_span', 'is_match'
         )
 
 

--- a/src/queries/views/query_state.py
+++ b/src/queries/views/query_state.py
@@ -93,7 +93,8 @@ def _get_base_state_entity(query):
 def _get_revision_update(query):
     results = QueryResult.get_latest_query_result_by_query_id(query["id"])
     matches_latest = MatchSerializer(Match.get_latest_matches_by_query_id(query["id"]), many=True).data
-    non_null_user_match = Match.objects.filter(query_result__query=query["id"], user_match__isnull=False)
+    # Find all matches that the user scored as True or False in the last round
+    non_null_user_match = Match.objects.filter(query_result=results["id"], user_match__isnull=False)
     user_matches = {}
     for match in non_null_user_match:
         user_matches.update({str(match.video_clip_id): match.user_match})


### PR DESCRIPTION
…ost recent query_result.

Otherwise, in the old version:
if a user marks a clip as, for example, Valid, and in a later round marks it as Invalid,
the earlier result is also found, and either one could be passed on.
Since I am now including all user scored clips in the new set of matches for each round (in algorithms),
we do not need to go further back than the latest query result to find all Validated and Invalidated
matches.